### PR TITLE
Proposed fixes #10 & #11 plus some numactl and wireTiger parameters

### DIFF
--- a/resources/mongodb-service.yaml
+++ b/resources/mongodb-service.yaml
@@ -8,8 +8,6 @@ spec:
   ports:
   - port: 27017
     targetPort: 27017
-    nodePort: 30000
-  type: NodePort
   # clusterIP: None # Set to "clusterIP: None" unless external access is required
   selector:
     role: mongo

--- a/resources/mongodb-service.yaml
+++ b/resources/mongodb-service.yaml
@@ -8,6 +8,8 @@ spec:
   ports:
   - port: 27017
     targetPort: 27017
+    nodePort: 30000
+  type: NodePort
   # clusterIP: None # Set to "clusterIP: None" unless external access is required
   selector:
     role: mongo

--- a/resources/mongodb-service.yaml
+++ b/resources/mongodb-service.yaml
@@ -8,20 +8,24 @@ spec:
   ports:
   - port: 27017
     targetPort: 27017
-  clusterIP: None
+  # clusterIP: None # Set to "clusterIP: None" unless external access is required
   selector:
     role: mongo
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: mongod
 spec:
   serviceName: mongodb-service
   replicas: 3
+  selector:
+    matchLabels:
+      app: app_mongod
   template:
     metadata:
       labels:
+        app: app_mongod
         role: mongo
         environment: test
         replicaset: MainRepSet
@@ -49,11 +53,11 @@ spec:
           #image: pkdone/mongo-ent:3.4
           image: mongo
           command:
-            - "numactl"
-            - "--interleave=all"
+            # - "numactl"
+            # - "--interleave=all"
             - "mongod"
             - "--wiredTigerCacheSizeGB"
-            - "0.1"
+            - "0.25"
             - "--bind_ip"
             - "0.0.0.0"
             - "--replSet"

--- a/scripts/configure_repset_auth.sh
+++ b/scripts/configure_repset_auth.sh
@@ -33,5 +33,6 @@ echo
 # Create a local port forwarding to connect mongodb clients
 echo " Creating port forward for mongodb-service to: 127.0.0.1:27017"
 kubectl port-forward service/mongodb-service 27017:27017 &
+minikube service mongodb-service &
 echo
 

--- a/scripts/configure_repset_auth.sh
+++ b/scripts/configure_repset_auth.sh
@@ -18,7 +18,7 @@ fi
 
 # Initiate replica set configuration
 echo "Configuring the MongoDB Replica Set"
-kubectl exec mongod-0 -c mongod-container -- mongo --eval 'rs.initiate({_id: "MainRepSet", version: 1, members: [ {_id: 0, host: "mongod-0.mongodb-service.default.svc.cluster.local:27017"}, {_id: 1, host: "mongod-1.mongodb-service.default.svc.cluster.local:27017"}, {_id: 2, host: "mongod-2.mongodb-service.default.svc.cluster.local:27017"} ]});'
+kubectl exec mongod-0 -c mongod-container -- mongo --eval 'rs.initiate({_id: "MainRepSet", version: 1, members: [ {_id: 0, host: "mongod-0.mongodb-service.default.svc.cluster.local:27017", priority: 1}, {_id: 1, host: "mongod-1.mongodb-service.default.svc.cluster.local:27017", priority: 0.5}, {_id: 2, host: "mongod-2.mongodb-service.default.svc.cluster.local:27017", priority: 1} ]});'
 
 # Wait a bit until the replica set should have a primary ready
 echo "Waiting for the Replica Set to initialise..."
@@ -33,6 +33,6 @@ echo
 # Create a local port forwarding to connect mongodb clients
 echo " Creating port forward for mongodb-service to: 127.0.0.1:27017"
 kubectl port-forward service/mongodb-service 27017:27017 &
-minikube service mongodb-service &
+echo "Connect string: mongodb://main_admin:<YOUR_PASSWORD>@0.0.0.0:27017/?authSource=admin&replicaSet=MainRepSet&readPreference=primary&appname=MongoDB%20Compass&directConnection=true&ssl=false"
 echo
 

--- a/scripts/configure_repset_auth.sh
+++ b/scripts/configure_repset_auth.sh
@@ -30,3 +30,8 @@ echo "Creating user: 'main_admin'"
 kubectl exec mongod-0 -c mongod-container -- mongo --eval 'db.getSiblingDB("admin").createUser({user:"main_admin",pwd:"'"${1}"'",roles:[{role:"root",db:"admin"}]});'
 echo
 
+# Create a local port forwarding to connect mongodb clients
+echo " Creating port forward for mongodb-service to: 127.0.0.1:27017"
+kubectl port-forward service/mongodb-service 27017:27017 &
+echo
+

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -10,5 +10,5 @@ kubectl delete secret shared-bootstrap-data
 sleep 3
 
 # Delete persistent volume claims
-kubectl delete persistentvolumeclaims -l role=mongo
+kubectl delete persistentvolumeclaims -l app=app_mongod
 


### PR DESCRIPTION
Resolving the k8 version/label problem as well as proposing a solution for mongodb access from the host machine using port-forwarding. Additionally addressing a few Mac M1 issue with numactl and TigerCache. This PR holds the complete fix including primary access which failed with just the port-forwarding - the PR changes mongod-0 replica to run with priority 1.